### PR TITLE
Added .vcxproj.user files in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,9 +27,10 @@
 *.out
 *.app
 
-#VS
+# Visual Studio
 Debug
 Release
 x64
 ipch
+*.vcxproj.user
 *.*sdf


### PR DESCRIPTION
These files are generated automatically in other projects using the AudioEndPointLibrary. Git then reports Submodule AudioEndPointLibrary Change - which is annoying...