### PR TITLE
Fix erroneous string escape sequence

### DIFF
--- a/DefSound/DefSoundEndpointColl.cpp
+++ b/DefSound/DefSoundEndpointColl.cpp
@@ -163,7 +163,7 @@ void EnumerateEndpoints(
         }
         catch (CError)
         {
-            DeviceClassIconPath.Get().pwszVal = L"%windir%\system32\mmres.dll,-3010";
+            DeviceClassIconPath.Get().pwszVal = L"%windir%\\system32\\mmres.dll,-3010";
         }
         
 


### PR DESCRIPTION
Noticed this while building in VS2019